### PR TITLE
escaping user provided variables in Jinja templates

### DIFF
--- a/steamlens/templates/gallery.jinja2
+++ b/steamlens/templates/gallery.jinja2
@@ -5,8 +5,8 @@
     <div class="col s12 m6 l4">
         <div class="card">
             <div class="card-image">
-                <a href="/item/{{ item_id }}">
-                    <img src="https://steamcdn-a.akamaihd.net/steam/apps/{{ item_id }}/header.jpg"
+                <a href="/item/{{ item_id|e }}">
+                    <img src="https://steamcdn-a.akamaihd.net/steam/apps/{{ item_id|e }}/header.jpg"
                     onerror="this.src='https://img.sine-x.com/404.jpg';" >
                 </a>
             </div>

--- a/steamlens/templates/page_app.jinja2
+++ b/steamlens/templates/page_app.jinja2
@@ -5,7 +5,7 @@
             <div class="card">
                 <div class="card-image">
                     <a href="#">
-                        <img src="https://steamcdn-a.akamaihd.net/steam/apps/{{ item_id }}/header.jpg"
+                        <img src="https://steamcdn-a.akamaihd.net/steam/apps/{{ item_id|e }}/header.jpg"
                         onerror="this.src='https://img.sine-x.com/404.jpg';">
                     </a>
                 </div>
@@ -14,7 +14,7 @@
         <div class="col">
             <div class="card">
                 <a class="waves-effect waves-light btn green darken-2"
-                   href="https://store.steampowered.com/app/{{ item_id }}/" target="_blank">
+                   href="https://store.steampowered.com/app/{{ item_id|e }}/" target="_blank">
                     <i class="material-icons left">add_shopping_cart</i>Buy on Steam
                 </a>
             </div>


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates.

This is a tricky issue. By default, Flask auto-escapes any Jinja template file that ends with `.html`, `.htm`, `.xml`, or `.xhtml`. Your template files end with the `.jinja` extension so they won't be auto-escaped. This may lead to XSS attacks. (https://checks.bento.dev/en/latest/flake8-flask/unescaped-file-extension/)

Looking at your code, you are passing `items` and `nickname` variables to `render_template()` function. I didn't look carefully how you populate the `g.user.nickname` value (so it is worth looking into that) but I went ahead and html-escaped the `items` value using the `{{value|e}}` pattern in Jinja.  (https://jinja.palletsprojects.com/en/2.10.x/templates/#working-with-manual-escaping)

Other than this, the code is really clean. Bento runs Flake8, Bandit and our custom checks and it didn't find anything else on your code. Feel free download and give Bento a try (https://bento.dev)